### PR TITLE
(backend) add env variable for maxDomains

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -171,6 +171,15 @@ export class Environment {
   );
 
   /**
+   * The maximum number of domains allowed to log in / create accounts.
+   * Defaults to 15.
+   */
+  @IsOptional()
+  @IsNumber()
+  public MAX_ALLOWED_DOMAINS = this.toOptionalNumber(process.env.MAX_ALLOWED_DOMAINS) ?? 15;
+
+
+  /**
    * The port that the server will listen on, defaults to 3000.
    */
   @IsNumber()

--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -48,7 +48,7 @@ export const PinValidation = {
 
 export const TeamValidation = {
   /** The maximum number of domains per instance */
-  maxDomains: ${env.MAX_ALLOWED_DOMAINS},
+  maxDomains: env.MAX_ALLOWED_DOMAINS,
 };
 
 export const UserValidation = {

--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -47,7 +47,7 @@ export const PinValidation = {
 
 export const TeamValidation = {
   /** The maximum number of domains per team */
-  maxDomains: 10,
+  maxDomains: 15,
 };
 
 export const UserValidation = {

--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -1,4 +1,4 @@
-import env from "@server/env";
+import env from "./env";
 export const AttachmentValidation = {
   /** The limited allowable mime-types for user and team avatars */
   avatarContentTypes: ["image/jpg", "image/jpeg", "image/png"],
@@ -48,7 +48,7 @@ export const PinValidation = {
 
 export const TeamValidation = {
   /** The maximum number of domains per instance */
-  maxDomains: env.MAX_ALLOWED_DOMAINS,
+  maxDomains: ${env.MAX_ALLOWED_DOMAINS},
 };
 
 export const UserValidation = {

--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -1,3 +1,4 @@
+import env from "@server/env";
 export const AttachmentValidation = {
   /** The limited allowable mime-types for user and team avatars */
   avatarContentTypes: ["image/jpg", "image/jpeg", "image/png"],
@@ -46,8 +47,8 @@ export const PinValidation = {
 };
 
 export const TeamValidation = {
-  /** The maximum number of domains per team */
-  maxDomains: 15,
+  /** The maximum number of domains per instance */
+  maxDomains: env.MAX_ALLOWED_DOMAINS,
 };
 
 export const UserValidation = {


### PR DESCRIPTION
# Context

Could not grant access to all DINUM due to maxDomains limitation because of hardcoded limitation to 10 domains.

![Capture d’écran du 2024-02-21 19-03-55](https://github.com/numerique-gouv/outline/assets/30848497/5df1333e-02df-4317-94f3-5fb73b7e4cfb)

# Proposal

Add optional environnment variable MAX_ALLOWED_DOMAINS to easily increase the number of allowed emails domains.
Default to 15.